### PR TITLE
Fix layer/spot.js to work with single features

### DIFF
--- a/src/layer/spot.js
+++ b/src/layer/spot.js
@@ -30,33 +30,12 @@ var SpotLayer = L.GeoJSON.extend({
             },
             messages = response.feedMessageResponse.messages.message;
 
-            if (response.feedMessageResponse.count === 1) {
-                geoJson.features.push({
-                geometry: {
-                  coordinates: [messages.longitude, messages.latitude],
-                  type: 'Point'
-                },
-                properties: messages,
-                type: 'Feature'
-              });
-            } else {
-              for (var i = 0; i < messages.length; i++) {
-                message = messages[i];
-
-                geoJson.features.push({
-                  geometry: {
-                    coordinates: [message.longitude, message.latitude],
-                    type: 'Point'
-                  },
-                  properties: message.messageContent,
-                  type: 'Feature'
-                });
-              }
+            if (!L.Util.isArray(messages)) {
+              messages = [messages];
             }
 
             for (var i = 0; i < messages.length; i++) {
               message = messages[i];
-
               geoJson.features.push({
                 geometry: {
                   coordinates: [message.longitude, message.latitude],

--- a/src/layer/spot.js
+++ b/src/layer/spot.js
@@ -30,6 +30,30 @@ var SpotLayer = L.GeoJSON.extend({
             },
             messages = response.feedMessageResponse.messages.message;
 
+            if (response.feedMessageResponse.count === 1) {
+                geoJson.features.push({
+                geometry: {
+                  coordinates: [messages.longitude, messages.latitude],
+                  type: 'Point'
+                },
+                properties: messages,
+                type: 'Feature'
+              });
+            } else {
+              for (var i = 0; i < messages.length; i++) {
+                message = messages[i];
+
+                geoJson.features.push({
+                  geometry: {
+                    coordinates: [message.longitude, message.latitude],
+                    type: 'Point'
+                  },
+                  properties: message.messageContent,
+                  type: 'Feature'
+                });
+              }
+            }
+
             for (var i = 0; i < messages.length; i++) {
               message = messages[i];
 


### PR DESCRIPTION
While working on a spot feed map, I noticed that the spot layer would only work when there were more than one message (i.e. point feature) in the spot xml feed. What I think was going on is that in this scenario, the messages property was not an Array, so so the "messages.length" was returning undefined in the For loop expression that adds the spot points to the geojson Features array.

I added an if statement that tests if the count property of the feedMessageResponse is equal to 1, and if so it pushes the single feature to the Feature Array of the geoJson variable, using the messages property.