### PR TITLE
Spot zoom cluster

### DIFF
--- a/src/layer/cluster.js
+++ b/src/layer/cluster.js
@@ -48,6 +48,13 @@ var ClusterLayer = L.MarkerClusterGroup.extend({
   onAdd: function(map) {
     this._map = map;
     this._addAttribution();
+
+    if (this.options.zoomToBounds) {
+      this.L.on('ready', function() {
+        map.fitBounds(this.getBounds());
+      })
+    };
+
     L.MarkerClusterGroup.prototype.onAdd.call(this, map);
   },
   onRemove: function(map) {

--- a/src/layer/spot.js
+++ b/src/layer/spot.js
@@ -94,9 +94,9 @@ var SpotLayer = L.GeoJSON.extend({
   _create: function(options, data) {
     L.GeoJSON.prototype.initialize.call(this, data, options);
 
-    if (options.zoomToBounds) {
-      this._map.fitBounds(this.getBounds());
-    }
+    //if (options.zoomToBounds) {
+      //this._map.fitBounds(this.getBounds());
+    //};
 
     this.fire('ready');
     this.readyFired = true;
@@ -112,5 +112,9 @@ module.exports = function(options) {
     options.type = 'spot';
   }
 
-  return new SpotLayer(options);
+  if (options.cluster) {
+    return L.npmap.layer._cluster(options);
+  } else {
+    return new SpotLayer(options);
+  }
 };

--- a/src/layer/spot.js
+++ b/src/layer/spot.js
@@ -93,14 +93,10 @@ var SpotLayer = L.GeoJSON.extend({
   },
   _create: function(options, data) {
     L.GeoJSON.prototype.initialize.call(this, data, options);
-
-    //if (options.zoomToBounds) {
-      //this._map.fitBounds(this.getBounds());
-    //};
-
     this.fire('ready');
     this.readyFired = true;
     this._loaded = true;
+    
     return this;
   }
 });

--- a/src/mixin/geojson.js
+++ b/src/mixin/geojson.js
@@ -28,6 +28,13 @@ module.exports = {
   onAdd: function(map) {
     this._map = map;
     this._addAttribution();
+
+    if (this.options.zoomToBounds) {
+      this.on('ready', function() {
+        map.fitBounds(this.getBounds());
+      })
+    };
+    
     L.GeoJSON.prototype.onAdd.call(this, map);
   },
   onRemove: function(map) {


### PR DESCRIPTION
This started off just trying to enable clustering in the spot layer - After that was fixed, I realized that zoomToBounds stopped working if clustering was enabled.  I added zoomToBounds logic to cluster.js to fix this.  

I also moved the zoomToBounds Logic from spot.js to mixin/geojson.js.  This enables zoomToBounds for all classes that include mixin/geojson.js.  Not sure if this is desirable in the other layer classes.