### PR TITLE
Additional spot options

### DIFF
--- a/API.md
+++ b/API.md
@@ -660,8 +660,8 @@ The first, and only, argument is required. It must be a config object comprised 
 * (Optional) `clickable` (Boolean): Should interactivity (hover and click) operations be enabled for this layer? Defaults to `true`.
 * (Optional) `cluster` (Boolean): Should the layer's markers be clustered?
 * (Optional) `description` (String): A description for the layer. Used by some [controls](#controls) and [modules](#modules).
-* (Optional) `latest` (Boolean): Only show the latest SPOT message (per device). Mutually exclusive with `minutesAgo`.
-* (Optional) `minutesAgo` (Number): Show SPOT messages from this number of mintues ago. Maximum is 10080 (7 days). Mutually exclusive with `latest`.
+* (Optional) `latest` (Boolean): Only show the latest SPOT message (per device). If `latest` and `minutesAgo` are both specified, `latest` takes precedence.
+* (Optional) `minutesAgo` (Number): Show SPOT messages from this number of minutes ago. Maximum is 10080 (7 days). If `latest` and `minutesAgo` are both specified, `latest` takes precedence.
 * (Optional) `name` (String): A name for the layer. Used by some [controls](#controls) and [modules](#modules).
 * (Optional) `password` (String): SPOT feed password.
 * (Optional) `popup` (String, Object, or Function): Configures the contents of the overlay's [popups](#using-popups).

--- a/API.md
+++ b/API.md
@@ -660,7 +660,10 @@ The first, and only, argument is required. It must be a config object comprised 
 * (Optional) `clickable` (Boolean): Should interactivity (hover and click) operations be enabled for this layer? Defaults to `true`.
 * (Optional) `cluster` (Boolean): Should the layer's markers be clustered?
 * (Optional) `description` (String): A description for the layer. Used by some [controls](#controls) and [modules](#modules).
+* (Optional) `latest` (Boolean): Only show the latest SPOT message (per device). Mutually exclusive with `minutesAgo`.
+* (Optional) `minutesAgo` (Number): Show SPOT messages from this number of mintues ago. Maximum is 10080 (7 days). Mutually exclusive with `latest`.
 * (Optional) `name` (String): A name for the layer. Used by some [controls](#controls) and [modules](#modules).
+* (Optional) `password` (String): SPOT feed password.
 * (Optional) `popup` (String, Object, or Function): Configures the contents of the overlay's [popups](#using-popups).
 * (Optional) `styles` (Object): Configures the overlay's [styles](#styling-vectors).
 * (Optional) `tooltip` (String, Object, or Function): Configures the contents of the overlay's [tooltips](#using-tooltips).

--- a/src/layer/spot.js
+++ b/src/layer/spot.js
@@ -11,7 +11,12 @@ var SpotLayer = L.GeoJSON.extend({
   ],
   initialize: function(options) {
     var me = this,
-      supportsCors = util.supportsCors();
+      supportsCors = util.supportsCors(),
+      startDate;
+
+    if (options.minutesAgo) {
+      startDate = new Date(new Date() - options.minutesAgo * 60000).toISOString().slice(0, -5) + '-0000';
+    }
 
     util.strict(options.id, 'string');
     L.Util.setOptions(this, this._toLeaflet(options));
@@ -86,7 +91,7 @@ var SpotLayer = L.GeoJSON.extend({
         }
       },
       type: 'json' + (supportsCors === 'yes' ? '' : 'p'),
-      url: 'https://npmap-proxy.herokuapp.com/?type=json&url=' + encodeURIComponent('https://api.findmespot.com/spot-main-web/consumer/rest-api/2.0/public/feed/' + options.id + '/message?dir=DESC&sort=timeInMili') + (supportsCors === 'yes' ? '' : '&callback=?')
+      url: 'https://npmap-proxy.herokuapp.com/?type=json&url=' + encodeURIComponent('https://api.findmespot.com/spot-main-web/consumer/rest-api/2.0/public/feed/' + options.id + (options.latest ? '/latest' : '/message') + '?dir=DESC&sort=timeInMili' + (options.password ? '&feedPassword=' + options.password : '') + (startDate ? '&startDate=' + startDate : '')) + (supportsCors === 'yes' ? '' : '&callback=?')
     });
 
     return this;


### PR DESCRIPTION
* Might want to think about throwing an error if the `minutesAgo` and `latest` options are both defined. They should be mutually exclusive. Right now, if both are defined, `latest` will take precedence since it is defined first in the URI.

* `password` option is plain text.  Not sure of the options here.. I guess it could be stored in a locked down external text file? The map I need this functionality for is intended to be internal only. I don't see a use case (for I&M) where a spot map would be shared publicly, and if it were, there would be no reason to make the spot feed password protected.

* I'll email you guys a spot feed ID and password to test the options with.