### PR TITLE
Infobox control

### DIFF
--- a/API.md
+++ b/API.md
@@ -67,7 +67,7 @@ The first, and only, argument is required. It must be a config object comprised 
 * (Optional) `hashControl` (Boolean): Defaults to `undefined`.
 * (Optional) `homeControl` (Boolean or Object): Defaults to `true`.
 * (Optional) `hooks` (Object): Add `init` and/or `preinit` hooks to the map. These must be functions that accept a `callback` parameter, and execute the `callback` function. Defaults to `undefined`.
-* (Optional) `infoBox` (Boolean): Defaults to `undefined`.
+* (Optional) `infoboxControl` (Boolean): Defaults to `undefined`.
 * (Optional) `legendControl` (Boolean or Object): Defaults to `undefined`.
 * (Optional) `locateControl` (Boolean or Object): Defaults to `undefined`.
 * (Optional) `measureControl` (Boolean or Object): Defaults to `undefined`.
@@ -1048,7 +1048,7 @@ _Example (Bootstrap)_:
 
     var NPMap = {
       div: 'map',
-      infoBox: true
+      infoboxControl: true
     };
 
 _Example (API)_:

--- a/API.md
+++ b/API.md
@@ -20,6 +20,7 @@
    * [geocoder](#geocoder)
    * [hash](#hash)
    * [home](#home)
+   * [infobox](#infobox)
    * [legend](#legend)
    * [locate](#locate)
    * [measure](#measure)
@@ -66,6 +67,7 @@ The first, and only, argument is required. It must be a config object comprised 
 * (Optional) `hashControl` (Boolean): Defaults to `undefined`.
 * (Optional) `homeControl` (Boolean or Object): Defaults to `true`.
 * (Optional) `hooks` (Object): Add `init` and/or `preinit` hooks to the map. These must be functions that accept a `callback` parameter, and execute the `callback` function. Defaults to `undefined`.
+* (Optional) `infoBox` (Boolean): Defaults to `undefined`.
 * (Optional) `legendControl` (Boolean or Object): Defaults to `undefined`.
 * (Optional) `locateControl` (Boolean or Object): Defaults to `undefined`.
 * (Optional) `measureControl` (Boolean or Object): Defaults to `undefined`.
@@ -1027,6 +1029,35 @@ _Example (API)_:
     var map = L.npmap.map({
       div: 'map'
     });
+
+**[[⬆]](#toc)**
+
+### <a name="infobox">infobox(config: object)</a>
+
+Create a control that displays tooltip information.
+
+_Extends_: [`L.Control`](http://leafletjs.com/reference.html#control)
+
+_Arguments_:
+
+You can (optionally) provide any of the options supported by [`L.Control`](http://leafletjs.com/reference.html#control).
+
+_Returns_: a control object
+
+_Example (Bootstrap)_:
+
+    var NPMap = {
+      div: 'map',
+      infoBox: true
+    };
+
+_Example (API)_:
+
+    var map = L.npmap.map({
+      div: 'map'
+    });
+
+    L.npmap.control.infobox().addTo(map);
 
 **[[⬆]](#toc)**
 

--- a/examples/infobox.html
+++ b/examples/infobox.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no">
+    <title>Tooltips | Examples | NPMap.js</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      #map {
+        bottom: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script>
+      var NPMap = {
+        center: {
+          lat: 45.3058,
+          lng: -116.7187
+        },
+        div: 'map',
+        infoboxControl: true,
+        overlays: [{
+          attribution: 'NPMap Team',
+          popup: {
+            title: '{{Description}}'
+          },
+          tooltip: '{{Name}}',
+          type: 'geojson',
+          url: 'data/rectangle.geojson'
+        },{
+          attribution: 'NPMap Team',
+          styles: {
+            'fill': '#d39800',
+            'fill-opacity': 0.2,
+            'stroke': '#d39800',
+            'stroke-opacity': 0.8,
+            'stroke-width': 3
+          },
+          table: 'parks',
+          tooltip: 'Alpha code: {{unit_code}}',
+          type: 'cartodb',
+          user: 'nps'
+        },{
+          attribution: 'Land Resources Division',
+          popup: {
+            description: 'The alpha code is {{Code}}.',
+            title: '{{Name}}'
+          },
+          styles: {
+            point: {
+              'marker-color': '#609321',
+              'marker-symbol': 'park'
+            }
+          },
+          tooltip: 'Center point for {{Code}}',
+          type: 'geojson',
+          url: 'data/national_parks.geojson'
+        }],
+        zoom: 6
+      };
+
+      (function() {
+        var s = document.createElement('script');
+        s.src = '../dist/npmap-bootstrap.js';
+        document.body.appendChild(s);
+      })();
+    </script>
+  </body>
+</html>

--- a/examples/tooltips.html
+++ b/examples/tooltips.html
@@ -26,7 +26,6 @@
           lng: -116.7187
         },
         div: 'map',
-        infoBox: true,
         overlays: [{
           attribution: 'NPMap Team',
           popup: {

--- a/examples/tooltips.html
+++ b/examples/tooltips.html
@@ -26,6 +26,7 @@
           lng: -116.7187
         },
         div: 'map',
+        infoBox: true,
         overlays: [{
           attribution: 'NPMap Team',
           popup: {

--- a/npmap.js
+++ b/npmap.js
@@ -17,6 +17,7 @@ L.npmap = module.exports = {
     edit: require('./src/control/edit'),
     fullscreen: require('./src/control/fullscreen'),
     hash: require('./src/control/hash'),
+    infobox: require('./src/control/infobox'),
     legend: require('./src/control/legend'),
     overview: require('./src/control/overview'),
     print: require('./src/control/print'),

--- a/src/control/infobox.js
+++ b/src/control/infobox.js
@@ -1,0 +1,81 @@
+/* global L */
+
+'use strict';
+
+var util = require('../util/util');
+
+var InfoboxControl = L.Control.extend({
+    options: {
+    position: 'bottomleft'
+  },
+  initialize: function(options) {
+    L.setOptions(this, options);
+
+    return this;
+  },
+  onAdd: function() {
+    this._container = L.DomUtil.create('div', 'leaflet-control-info leaflet-control');
+
+    return this._container;
+  },
+  _hide: function() {
+    this._container.style.display = 'none';
+    L.DomUtil.removeClass(this._container, 'leaflet-tooltip-fade');
+
+    if (this._map.activeTip === this) {
+      delete this._map.activeTip;
+    }
+  },
+  _show: function() {
+    this._container.style.display = 'inline-block';
+    L.DomUtil.addClass(this._container, 'leaflet-tooltip-fade');
+  },
+  getHtml: function() {
+    return this._container.innerHTML;
+  },
+  hide: function() {
+    this._hide();
+  },
+  isVisible: function() {
+    return this._container.style.display !== 'none';
+  },
+  setHtml: function (html) {
+    this._container.innerHTML = util.unescapeHtml(html);
+  },
+  setPosition: function () {
+    return
+  },
+  show: function(centerpoint, html) {
+    if (this._map.activeTip && (this._map.activeTip !== this)) {
+      this._map.activeTip._hide();
+    }
+
+    this._map.activeTip = this;
+
+    if (html) {
+      this.setHtml(html);
+    }
+
+      this._show();
+  }
+});
+
+L.Map.mergeOptions({
+  infoBox: false
+});
+
+L.Map.addInitHook(function() {
+  if (this.options.infoBox) {
+    var options = {};
+
+    if (typeof this.options.infoBox === 'object') {
+      options = this.options.infoBox;
+    }
+
+    this.infoboxControl = L.npmap.control.infobox(options).addTo(this);
+  }
+});
+
+module.exports = function(options) {
+  return new InfoboxControl(options);
+};

--- a/src/control/infobox.js
+++ b/src/control/infobox.js
@@ -61,15 +61,15 @@ var InfoboxControl = L.Control.extend({
 });
 
 L.Map.mergeOptions({
-  infoBox: false
+  infoboxControl: false
 });
 
 L.Map.addInitHook(function() {
-  if (this.options.infoBox) {
+  if (this.options.infoboxControl) {
     var options = {};
 
-    if (typeof this.options.infoBox === 'object') {
-      options = this.options.infoBox;
+    if (typeof this.options.infoboxControl === 'object') {
+      options = this.options.infoboxControl;
     }
 
     this.infoboxControl = L.npmap.control.infobox(options).addTo(this);

--- a/src/map.js
+++ b/src/map.js
@@ -489,9 +489,7 @@ var Map = L.Map.extend({
   _setupTooltip: function() {
     var me = this,
       overData = [],
-      tooltip = L.npmap.tooltip({
-        map: me
-      });
+      tooltip = (me.infoboxControl ? me.infoboxControl : L.npmap.tooltip({map: me}));
 
     function handle() {
       if (me._controllingCursor === 'map') {

--- a/theme/nps.css
+++ b/theme/nps.css
@@ -1022,6 +1022,14 @@
   background-image: url('images/font-awesome/home@2x.png');
 }
 
+/* Info Control */
+.npmap .leaflet-control-info {
+  background-color: #fff;
+  display: none;
+  padding: 3px 5px;
+  transition: all .2s;
+}
+
 /* Legend Control */
 .npmap .leaflet-control-legend {
   background-color: #fff;


### PR DESCRIPTION
Are you folks happy with the `infoBox` property name in the NPMap config object?  When I was updating the API doc, I realized `infoboxControl` is probably more consistent.

I defined all the `L.npmap.tooltip()` methods in `L.npmap.control.infobox()`, thinking in terms of an OOP interface.  Is it worth documenting this "tooltip" interface similar to how the [leaflet docs](http://leafletjs.com/reference.html#icontrol) document them?

I wanted this feature for this Vegetation Inventory Project Map I'm working on. [Dataset preview](https://api.tiles.mapbox.com/v4/ryanjhodge.23f33aa8/page.html?access_token=pk.eyJ1Ijoicnlhbmpob2RnZSIsImEiOiJ5clRfMjRRIn0.KldXlC8cT9zpaQGY_YSOGQ#13/34.0394/-116.3559)