### PR TITLE
Switcher zoom level issues

### DIFF
--- a/src/control/switcher.js
+++ b/src/control/switcher.js
@@ -109,6 +109,12 @@ var SwitcherControl = L.Control.extend({
             baseLayer.L = L.npmap.layer[baseLayer.type](baseLayer);
           }
 
+          if (this._map.getZoom() < baseLayer.minZoom) {
+            this._map.setView(this._map.getCenter(), baseLayer.minZoom);
+          } else if (this._map.getZoom() > baseLayer.maxZoom) {
+            this._map.setView(this._map.getCenter(), baseLayer.maxZoom);
+          }
+
           this._map.addLayer(baseLayer.L, true);
           L.DomUtil.addClass(target, 'selected');
           this._setActive(baseLayer);

--- a/src/control/switcher.js
+++ b/src/control/switcher.js
@@ -115,6 +115,12 @@ var SwitcherControl = L.Control.extend({
             this._map.setView(this._map.getCenter(), baseLayer.maxZoom);
           }
 
+          if(baseLayer.maxZoom) {
+            this._map.options.maxZoom = baseLayer.maxZoom;
+          } else {
+            this._map.options.maxZoom = 19;
+          }
+
           this._map.addLayer(baseLayer.L, true);
           L.DomUtil.addClass(target, 'selected');
           this._setActive(baseLayer);

--- a/src/control/switcher.js
+++ b/src/control/switcher.js
@@ -108,6 +108,12 @@ var SwitcherControl = L.Control.extend({
           } else {
             baseLayer.L = L.npmap.layer[baseLayer.type](baseLayer);
           }
+          
+          if (this._map.getZoom() < baseLayer.minZoom) {
+            this._map.setView(this._map.getCenter(), baseLayer.minZoom);
+          } else if (this._map.getZoom() > baseLayer.maxZoom) {
+            this._map.setView(this._map.getCenter(), baseLayer.maxZoom);
+          }
 
           if (this._map.getZoom() < baseLayer.minZoom) {
             this._map.setView(this._map.getCenter(), baseLayer.minZoom);

--- a/src/control/switcher.js
+++ b/src/control/switcher.js
@@ -108,12 +108,6 @@ var SwitcherControl = L.Control.extend({
           } else {
             baseLayer.L = L.npmap.layer[baseLayer.type](baseLayer);
           }
-          
-          if (this._map.getZoom() < baseLayer.minZoom) {
-            this._map.setView(this._map.getCenter(), baseLayer.minZoom);
-          } else if (this._map.getZoom() > baseLayer.maxZoom) {
-            this._map.setView(this._map.getCenter(), baseLayer.maxZoom);
-          }
 
           if (this._map.getZoom() < baseLayer.minZoom) {
             this._map.setView(this._map.getCenter(), baseLayer.minZoom);

--- a/src/control/switcher.js
+++ b/src/control/switcher.js
@@ -110,9 +110,13 @@ var SwitcherControl = L.Control.extend({
           }
 
           if (this._map.getZoom() < baseLayer.minZoom) {
-            this._map.setView(this._map.getCenter(), baseLayer.minZoom);
+            setTimeout(function(map, baselayer) {
+              map.setView(map.getCenter(), baselayer.minZoom);
+            }, 200, this._map, baseLayer);
           } else if (this._map.getZoom() > baseLayer.maxZoom) {
-            this._map.setView(this._map.getCenter(), baseLayer.maxZoom);
+            setTimeout(function(map, baselayer) {
+              map.setView(map.getCenter(), baselayer.maxZoom);
+            }, 200, this._map, baseLayer);
           }
 
           if(baseLayer.maxZoom) {

--- a/src/map.js
+++ b/src/map.js
@@ -759,17 +759,19 @@ var Map = L.Map.extend({
       config.maxZoom = 19;
     }
 
-    if (config.maxZoom > config.baseLayers[0].maxZoom) {
+    if (config.baseLayers.length !== 0 && config.maxZoom > config.baseLayers[0].maxZoom) {
       config.maxZoom = config.baseLayers[0].maxZoom;
     }
 
     delete config.layers;
     config.zoom = typeof config.zoom === 'number' ? config.zoom : 4;
 
-    if (config.baseLayers[0].minZoom > config.zoom) {
-      config.zoom = config.baseLayers[0].minZoom;
-    } else if (config.baseLayers[0].maxZoom < config.zoom) {
-      config.zoom = config.baseLayers[0].maxZoom;
+    if (config.baseLayers.length !== 0) {
+      if (config.baseLayers[0].minZoom > config.zoom) {
+        config.zoom = config.baseLayers[0].minZoom;
+      } else if (config.baseLayers[0].maxZoom < config.zoom) {
+        config.zoom = config.baseLayers[0].maxZoom;
+      }
     }
 
     return config;

--- a/src/map.js
+++ b/src/map.js
@@ -759,8 +759,19 @@ var Map = L.Map.extend({
       config.maxZoom = 19;
     }
 
+    if (config.maxZoom > config.baseLayers[0].maxZoom) {
+      config.maxZoom = config.baseLayers[0].maxZoom;
+    }
+
     delete config.layers;
     config.zoom = typeof config.zoom === 'number' ? config.zoom : 4;
+
+    if (config.baseLayers[0].minZoom > config.zoom) {
+      config.zoom = config.baseLayers[0].minZoom;
+    } else if (config.baseLayers[0].maxZoom < config.zoom) {
+      config.zoom = config.baseLayers[0].maxZoom;
+    }
+
     return config;
   },
   _updateImproveLinks: function() {


### PR DESCRIPTION
- If the map's current zoom level is outside of the selected baselayer's zoom range, sets the map's zoom level to the min/max zoom level of the selected baselayer
- Set's the map's `maxZoom` option to the selected baselayer's `maxZoom`, if not specified by baselayer then set map's `maxZoom` to 19