### PR TITLE
Test hostname instead of origin in `isLocalUrl`

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -614,7 +614,7 @@ module.exports = {
     return (el.offsetParent === null);
   },
   isLocalUrl: function (url) {
-    if (url.indexOf(window.location.origin) === 0) {
+    if (url.indexOf(window.location.hostname) >= 0) {
       return true;
     } else {
       return !(/^(?:[a-z]+:)?\/\//i.test(url));


### PR DESCRIPTION
I used express.js to create a geojson service on top of SQL Server.  It's running locally at `127.0.0.1:3000/forestveg`  While developing, I use npm http-server package to host my development webpages at `127.0.0.1:8080`

npmap.js was not recognizing the geojson service URL as a local URL and was using the proxy for a CORS request, that is, the `isLocalUrl()` function was returning `false` because the origin has a different port number than the geojson service.  Testing the hostname solved this problem for me since it returns the hostname without the port number and `isLocalUrl()` evaluates to `true`

I wanted to run this by you guys to see if there's a better solution, or if I should change up my dev environment.

Eventually the service will run internally on a separate host, in which case, I will probably run into the same problem again. Maybe there is a way to detect whether a geojson source is on the internal network?